### PR TITLE
Fix build errors for angular 13

### DIFF
--- a/projects/carousel/src/lib/carousel.module.ts
+++ b/projects/carousel/src/lib/carousel.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, Injectable } from '@angular/core';
+import { NgModule, Injectable, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -10,7 +10,6 @@ import {
   HAMMER_GESTURE_CONFIG,
   HammerModule
 } from '@angular/platform-browser';
-import { ModuleWithProviders } from '@angular/compiler/src/core';
 
 // https://github.com/angular/angular/issues/10541#issuecomment-300761387
 @Injectable()
@@ -26,7 +25,7 @@ export class MatCarouselHammerConfig extends HammerGestureConfig {
   exports: [MatCarouselComponent, MatCarouselSlideComponent]
 })
 export class MatCarouselModule {
-  static forRoot(): ModuleWithProviders {
+  static forRoot(): ModuleWithProviders<MatCarouselModule> {
     return {
       ngModule: MatCarouselModule,
       providers: [


### PR DESCRIPTION
ModuleWithProviders should also be imported from '@angular/core' and not '@angular/compiler/src/core'